### PR TITLE
set git config push.default #43

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -28,6 +28,12 @@
     name: user.email
     value: "{{ git_email }}"
 
+- name: git push.default set
+  git_config:
+    scope: global
+    name: push.default
+    value: current
+
 - name: make vim directories
   file:
     path: "{{ item }}"


### PR DESCRIPTION
This is awesome change!!!

The push command changed from `git push origin feature/tochi/43-set-git-config-push:feature/tochi/43-set-git-config-push` to `gps`. Amazing!!
